### PR TITLE
Use xenial apt repository as no other distro is provided

### DIFF
--- a/tasks/Ubuntu.yml
+++ b/tasks/Ubuntu.yml
@@ -21,7 +21,7 @@
 - name: Configure osquery APT repository
   become: yes
   apt_repository:
-    repo: 'deb [arch=amd64] https://osquery-packages.s3.amazonaws.com/{{ ansible_distribution_release | lower }} {{ ansible_distribution_release | lower }} main'
+    repo: 'deb [arch=amd64] https://osquery-packages.s3.amazonaws.com/xenial xenial main'
     state: present
   tags:
     - osquery


### PR DESCRIPTION
https://osquery.readthedocs.io/en/stable/installation/install-linux/#dpkg-based-distros only lists `https://osquery-packages.s3.amazonaws.com/xenial xenial main` as the apt repository and will 404 if any other distro name is used. 

this has been tested and works on 16.04 and 18.04